### PR TITLE
Add terminal-style code blocks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -41,3 +41,6 @@ theme     = "ananke"
     [markup.goldmark.parser]
       attribute = true
 
+[params]
+  customCSS = ["css/terminal.css"]
+

--- a/static/css/terminal.css
+++ b/static/css/terminal.css
@@ -1,0 +1,20 @@
+pre {
+  background-color: #1e1e1e;
+  color: #c5c8c6;
+  padding: 1.5em 1em 1em;
+  border-radius: 5px;
+  overflow-x: auto;
+  font-family: "Courier New", Courier, monospace;
+  position: relative;
+}
+pre::before {
+  content: "";
+  position: absolute;
+  top: 0.5em;
+  left: 0.75em;
+  width: 0.6em;
+  height: 0.6em;
+  border-radius: 50%;
+  background: #ff5f56;
+  box-shadow: 0.9em 0 0 0 #ffbd2e, 1.8em 0 0 0 #27c93f;
+}


### PR DESCRIPTION
## Summary
- add new terminal-style CSS
- link custom CSS in config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840e7a0b76c832d982b3a7719e04ee2