### PR TITLE
Fix future posts not showing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,9 @@ languageCode = "en-us"
 title     = "ITonTAP Home"
 theme     = "ananke"
 
+[build]
+  buildFuture = true
+
 [menu]
 
   [[menu.main]]


### PR DESCRIPTION
## Summary
- allow building future-dated posts

## Testing
- `hugo --gc --minify --logLevel debug -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b74bdf40832d8fdb3f87d045631a