### PR TITLE
Improve code block rendering

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,4 +46,5 @@ theme     = "ananke"
 
 [params]
   customCSS = ["css/terminal.css"]
+  customJS = ["js/codeblock.js"]
 

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,0 +1,8 @@
+{{- $lang := .Language | default "text" -}}
+<div class="codeblock">
+  <div class="codeblock-header">
+    <span class="codeblock-lang">{{ $lang }}</span>
+    <button class="copy-btn" type="button">Copy</button>
+  </div>
+  {{- highlight .Inner $lang "" | safeHTML -}}
+</div>

--- a/static/css/terminal.css
+++ b/static/css/terminal.css
@@ -1,20 +1,49 @@
-pre {
+.codeblock {
   background-color: #1e1e1e;
   color: #c5c8c6;
-  padding: 1.5em 1em 1em;
   border-radius: 5px;
-  overflow-x: auto;
   font-family: "Courier New", Courier, monospace;
+  overflow: hidden;
   position: relative;
+  margin: 1em 0;
 }
-pre::before {
+
+.codeblock-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4em 0.8em;
+  background-color: #1e1e1e;
+  border-bottom: 1px solid #444;
+}
+
+.codeblock-header::before {
   content: "";
-  position: absolute;
-  top: 0.5em;
-  left: 0.75em;
+  display: inline-block;
   width: 0.6em;
   height: 0.6em;
   border-radius: 50%;
   background: #ff5f56;
-  box-shadow: 0.9em 0 0 0 #ffbd2e, 1.8em 0 0 0 #27c93f;
+  box-shadow: 0.8em 0 0 #ffbd2e, 1.6em 0 0 #27c93f;
+  margin-right: 0.75em;
+}
+
+.codeblock-lang {
+  font-size: 0.8em;
+  text-transform: uppercase;
+  color: #ffffff;
+}
+
+.copy-btn {
+  background: none;
+  border: none;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 0.8em;
+}
+
+.codeblock pre {
+  margin: 0;
+  padding: 1em;
+  overflow-x: auto;
 }

--- a/static/js/codeblock.js
+++ b/static/js/codeblock.js
@@ -1,0 +1,14 @@
+window.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.copy-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var code = btn.parentElement.nextElementSibling;
+      if (code) {
+        navigator.clipboard.writeText(code.innerText).then(function() {
+          var original = btn.textContent;
+          btn.textContent = 'Copied';
+          setTimeout(function(){ btn.textContent = original; }, 2000);
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- enhance code block styling and add copy functionality
- load new script via config
- override Hugo render hook for fenced code blocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da18b2950832d81ea8d3e49f55368