### PR TITLE
Improve terminal code blocks

### DIFF
--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,7 +1,7 @@
 {{- $lang := .Language | default "text" -}}
-<div class="codeblock">
+<div class="codeblock" data-lang="{{ $lang }}">
   <div class="codeblock-header">
-    <span class="codeblock-lang">{{ $lang }}</span>
+  <span class="codeblock-lang">{{ $lang | upper }}</span>
     <button class="copy-btn" type="button">Copy</button>
   </div>
   {{- highlight .Inner $lang "" | safeHTML -}}

--- a/static/css/terminal.css
+++ b/static/css/terminal.css
@@ -6,6 +6,7 @@
   overflow: hidden;
   position: relative;
   margin: 1em 0;
+  border: 1px solid #444;
 }
 
 .codeblock-header {
@@ -13,7 +14,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.4em 0.8em;
-  background-color: #1e1e1e;
+  background-color: #2b2b2b;
   border-bottom: 1px solid #444;
 }
 
@@ -46,4 +47,5 @@
   margin: 0;
   padding: 1em;
   overflow-x: auto;
+  overflow-y: hidden;
 }


### PR DESCRIPTION
## Summary
- make code blocks more terminal-like
- show language tag in header
- avoid vertical scrollbars on code blocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da5e69040832d98840494da6fb41f