### PR TITLE
Improve terminal code blocks

### DIFF
--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,7 +1,7 @@
-{{- $lang := .Language | default "text" -}}
-<div class="codeblock">
+{{- $lang := .Type | default "text" -}}
+<div class="codeblock" data-lang="{{ $lang }}">
   <div class="codeblock-header">
-    <span class="codeblock-lang">{{ $lang }}</span>
+  <span class="codeblock-lang">{{ $lang | upper }}</span>
     <button class="copy-btn" type="button">Copy</button>
   </div>
   {{- highlight .Inner $lang "" | safeHTML -}}

--- a/static/css/terminal.css
+++ b/static/css/terminal.css
@@ -6,30 +6,31 @@
   overflow: hidden;
   position: relative;
   margin: 1em 0;
+  border: 1px solid #444;
 }
 
+
 .codeblock-header {
+  position: absolute;
+  top: 0.3em;
+  right: 0.4em;
   display: flex;
-  justify-content: space-between;
+  gap: 0.4em;
+  padding: 0.1em 0.4em;
+  font-size: 0.7em;
+  background-color: rgba(43, 43, 43, 0.8);
+  border-radius: 3px;
   align-items: center;
-  padding: 0.4em 0.8em;
-  background-color: #1e1e1e;
-  border-bottom: 1px solid #444;
 }
+
 
 .codeblock-header::before {
   content: "";
-  display: inline-block;
-  width: 0.6em;
-  height: 0.6em;
-  border-radius: 50%;
-  background: #ff5f56;
-  box-shadow: 0.8em 0 0 #ffbd2e, 1.6em 0 0 #27c93f;
-  margin-right: 0.75em;
+  display: none;
 }
 
 .codeblock-lang {
-  font-size: 0.8em;
+  font-size: 0.75em;
   text-transform: uppercase;
   color: #ffffff;
 }
@@ -39,11 +40,13 @@
   border: none;
   color: #ffffff;
   cursor: pointer;
-  font-size: 0.8em;
+  padding: 0;
+  font-size: 1em;
 }
 
 .codeblock pre {
   margin: 0;
-  padding: 1em;
+  padding: 1.5em 1em 1em;
   overflow-x: auto;
+  overflow-y: hidden;
 }


### PR DESCRIPTION
## Summary
- overlay header inside code blocks
- shrink code language display
- adjust padding for overlay and remove vertical scrollbars

## Testing
- `hugo --gc --minify` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da5e69040832d98840494da6fb41f