### PR TITLE
Improve code block styling

### DIFF
--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,8 +1,8 @@
 {{- $lang := .Type | default "text" -}}
 <div class="codeblock" data-lang="{{ $lang }}">
   <div class="codeblock-header">
-  <span class="codeblock-lang">{{ $lang | upper }}</span>
-    <button class="copy-btn" type="button">Copy</button>
+    <span class="codeblock-lang">{{ $lang | upper }}</span>
+    <button class="copy-btn" type="button" aria-label="Copy code">Copy</button>
   </div>
   {{- highlight .Inner $lang "" | safeHTML -}}
 </div>

--- a/static/css/terminal.css
+++ b/static/css/terminal.css
@@ -9,27 +9,18 @@
   border: 1px solid #444;
 }
 
-
 .codeblock-header {
   position: absolute;
-  top: 0.3em;
-  right: 0.4em;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
-  gap: 0.4em;
-  padding: 0.1em 0.4em;
-  font-size: 0.7em;
-  background-color: rgba(43, 43, 43, 0.8);
-  border-radius: 3px;
+  justify-content: space-between;
   align-items: center;
-  padding: 0.4em 0.8em;
+  padding: 0.25em 0.5em;
+  font-size: 0.7em;
   background-color: #2b2b2b;
   border-bottom: 1px solid #444;
-}
-
-
-.codeblock-header::before {
-  content: "";
-  display: none;
 }
 
 .codeblock-lang {
@@ -39,17 +30,23 @@
 }
 
 .copy-btn {
-  background: none;
+  background-color: #444;
   border: none;
   color: #ffffff;
   cursor: pointer;
-  padding: 0;
-  font-size: 1em;
+  padding: 0.2em 0.6em;
+  font-size: 0.7em;
+  border-radius: 3px;
+  transition: background-color 0.2s;
+}
+
+.copy-btn:hover {
+  background-color: #666;
 }
 
 .codeblock pre {
   margin: 0;
-  padding: 1.5em 1em 1em;
+  padding: 1.8em 1em 1em;
   overflow-x: auto;
   overflow-y: hidden;
 }


### PR DESCRIPTION
## Summary
- style code block header across the top
- show language on the left and move copy button to the right
- modernize button and padding

## Testing
- `hugo -D` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dac9b8e44832d9ec97c33a7d0a850